### PR TITLE
Install request as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "chai": "^3.4.0",
+    "request": "^2.75.0",
     "request-promise": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Because for some reason it's what broke recently e.g. in https://github.com/feathersjs/feathers-memory/pull/40
