### PR TITLE
Support $select in get and make sure patch many only returns changed items

### DIFF
--- a/src/common-tests.js
+++ b/src/common-tests.js
@@ -57,7 +57,7 @@ function common (app, errors, serviceName = 'people', idProp = 'id') {
         }).then(data => {
           expect(data[idProp].toString()).to.equal(_ids.Doug.toString());
           expect(data.name).to.equal('Doug');
-          expect(data.age).to.not.exist();
+          expect(data.age).to.not.exist;
         });
       });
 

--- a/src/common-tests.js
+++ b/src/common-tests.js
@@ -187,6 +187,17 @@ function common (app, errors, serviceName = 'people', idProp = 'id') {
             .then(data => expect(data.length).to.equal(2));
         });
 
+        it('can $limit 0', () => {
+          const params = {
+            query: {
+              $limit: 0
+            }
+          };
+
+          app.service(serviceName).find(params)
+            .then(data => expect(data.length).to.equal(0));
+        });
+
         it('can $skip', () => {
           const params = {
             query: {


### PR DESCRIPTION
Related to https://github.com/feathersjs/feathers/issues/450 and https://github.com/feathersjs/feathers-mongoose/pull/124#discussion_r86707375

Closes #25 

@feathersjs/core-team Should $select be tested and supported for `patch`, `update`, `remove` and `create` as well?