### PR TITLE
Do not rely on order of items returned without sorting.

### DIFF
--- a/src/common-tests.js
+++ b/src/common-tests.js
@@ -433,16 +433,26 @@ function common (app, errors, serviceName = 'people', idProp = 'id') {
         afterEach(() => (app.service(serviceName).paginate = {}));
 
         it('returns paginated object, paginates by default and shows total', () => {
-          return app.service(serviceName).find().then(paginator => {
-            expect(paginator.total).to.equal(3);
-            expect(paginator.limit).to.equal(1);
-            expect(paginator.skip).to.equal(0);
-            expect(paginator.data[0].name).to.equal('Doug');
-          });
+          return app.service(serviceName)
+            .find({ query: { $sort: { name: -1 } } })
+            .then(paginator => {
+              expect(paginator.total).to.equal(3);
+              expect(paginator.limit).to.equal(1);
+              expect(paginator.skip).to.equal(0);
+              expect(paginator.data[0].name).to.equal('Doug');
+            });
         });
 
         it('paginates max and skips', () => {
-          return app.service(serviceName).find({ query: { $skip: 1, $limit: 4 } }).then(paginator => {
+          const params = {
+            query: {
+              $skip: 1,
+              $limit: 4,
+              $sort: { name: -1 }
+            }
+          };
+
+          return app.service(serviceName).find(params).then(paginator => {
             expect(paginator.total).to.equal(3);
             expect(paginator.limit).to.equal(2);
             expect(paginator.skip).to.equal(1);

--- a/src/example-tests.js
+++ b/src/example-tests.js
@@ -29,7 +29,11 @@ export default function (idProp = 'id', url = 'http://localhost:3030/todos') {
 
   describe('GET /', () => {
     it('GET / with default pagination', () => {
-      return request({ url, json: true }).then(page => {
+      return request({
+        url,
+        json: true,
+        qs: { $sort: { text: 1 } }
+      }).then(page => {
         expect(page.total).to.equal(3);
         expect(page.limit).to.equal(2);
         expect(page.skip).to.equal(0);
@@ -43,7 +47,7 @@ export default function (idProp = 'id', url = 'http://localhost:3030/todos') {
       return request({
         url,
         json: true,
-        qs: { $skip: 2 }
+        qs: { $skip: 2, $sort: { text: 1 } }
       }).then(page => {
         expect(page.total).to.equal(3);
         expect(page.limit).to.equal(2);


### PR DESCRIPTION
### Summary

The following two tests for paginated results:

- returns paginated object, paginates by default and shows total
- paginates max and skips

were relying on the order of items returned from the storage without sorting applied. While this can work sometimes, many databases claim that the order of items returned without sorting applied is non-deterministic. This definitely holds true for Elasticsearch.

This PR simply adds sorting by name to the tests mentioned above.

There are no issues opened, which relate to this PR.
This PR is not dependent on any PRs in other repos.
