### PR TITLE
Update ORM tests to cover revove() method

### DIFF
--- a/src/orm-tests.js
+++ b/src/orm-tests.js
@@ -69,6 +69,12 @@ export default function orm (people, errors, idProp = 'id') {
           expect(Object.getPrototypeOf(result)).to.equal(Object.prototype)
         ).catch(noPOJO);
       });
+
+      it('returns a POJO for remove()', () => {
+        return people.remove(_ids.Doug).then(result =>
+          expect(Object.getPrototypeOf(result)).to.equal(Object.prototype)
+        ).catch(noPOJO);
+      });
     });
   });
 }


### PR DESCRIPTION
This is a fixup to include coverage for the remove() method on ORM objects. This has been tested with the new changes in both feathers-sequelize and feathers-mongoose.